### PR TITLE
Fixing deprecated callbacks and solves a git checkout problem

### DIFF
--- a/fserver.drush.inc
+++ b/fserver.drush.inc
@@ -346,7 +346,7 @@ class FserverProject_git {
 
       // Retrieve tag info
       _drush_shell_exec_output_set(' '); // Clear output cache.
-      drush_op('drush_shell_exec', "git --git-dir={$this->path}/.git show {$vc}");
+      drush_op('drush_shell_exec', "git --git-dir={$this->path}/.git --work-tree={$this->path} show {$vc}");
       $info = drush_shell_exec_output();
       if ($info[0] == "tag {$vc}") {
         $info = implode("\n", $info);
@@ -378,7 +378,7 @@ class FserverProject_git {
         // Create the directory if it doesn't exist.
         if (file_check_directory($file_path, TRUE)) {
           $vc = $tag['original'];
-          drush_op('drush_shell_exec', "git --git-dir={$this->path}/.git checkout {$vc}");
+          drush_op('drush_shell_exec', "git --git-dir={$this->path}/.git --work-tree={$this->path} checkout {$vc}");
           $this->FserverProject->write_package_info($tag, array('.git'));
           drush_op('drush_shell_exec', "tar -Pcf - --exclude='.git' --transform='s,{$this->path},{$this->FserverProject->name},' {$this->path} | gzip > {$file_path}/{$base}.tgz");
 

--- a/fserver.drush.inc
+++ b/fserver.drush.inc
@@ -22,15 +22,12 @@
 function fserver_drush_command() {
   $items = array();
   $items['fserver-status'] = array(
-    'callback' => 'fserver_drush_status',
     'description' => 'Determine the packaging status of a project.',
   );
   $items['fserver-package'] = array(
-    'callback' => 'fserver_drush_package',
     'description' => 'Update packaging for a project.',
   );
   $items['fserver-distro'] = array(
-    'callback' => 'fserver_drush_distro',
     'description' => 'Update packaging for a distribution.',
   );
   return $items;
@@ -53,7 +50,7 @@ function fserver_drush_help($section) {
 /**
  * Package new releases for a specified project or all.
  */
-function fserver_drush_package() {
+function drush_fserver_package() {
   if (!drush_get_option('uri') && !drush_get_option('l')) {
     drush_die('You must use the --uri option to specify the location of this site.');
   }
@@ -94,7 +91,7 @@ function fserver_drush_package() {
 /**
  * Display project packaging status.
  */
-function fserver_drush_status() {
+function drush_fserver_status() {
   $projects = _fserver_drush_get_projects();
 
   // Filter the project list by the argument.
@@ -564,7 +561,7 @@ function fserver_posix_groupname() {
   return NULL;
 }
 
-function fserver_drush_distro() {
+function drush_fserver_distro() {
   if (!drush_get_option('version')) {
     drush_die('No version supplied, please use --version to specify a version for your release.');
   }

--- a/views/fserver-updatexml.tpl.php
+++ b/views/fserver-updatexml.tpl.php
@@ -5,36 +5,26 @@
   <title><?php print $project['title'] ?></title>
   <short_name><?php print $project['short_name'] ?></short_name>
   <api_version><?php print $project['api_version'] ?></api_version>
-
   <recommended_major><?php print $project['recommended_major'] ?></recommended_major>
   <supported_majors><?php print $project['supported_majors'] ?></supported_majors>
   <default_major><?php print $project['recommended_major'] ?></default_major>
-
   <project_status>1</project_status>
-
   <link><?php print $project['link'] ?></link>
-
   <terms>
     <term>
       <name>Projects</name>
       <value><?php print $project['type'] ?></value>
     </term>
   </terms>
-
   <releases>
     <?php foreach ($releases as $release): ?>
-
     <release>
-
       <name><?php print $release['name'] ?></name>
       <version><?php print $release['version'] ?></version>
-
       <version_major><?php print $release['version_major'] ?></version_major>
       <version_patch><?php print $release['version_patch'] ?></version_patch>
       <?php if (!empty($release['version_extra'])): ?><version_extra><?php print $release['version_extra'] ?></version_extra><?php endif; ?>
-
       <status>published</status>
-
       <release_link><?php print $release['release_link'] ?></release_link>
       <download_link><?php print $release['download_link'] ?></download_link>
       <date><?php print $release['date'] ?></date>
@@ -46,10 +36,8 @@
           <value>Security update</value>
         </term>
       </terms><?php endif; ?>
-
     </release>
     <?php endforeach; ?>
-
   </releases>
 </project>
 <?php else: ?>

--- a/views/fserver_plugin_style_updatexml.inc
+++ b/views/fserver_plugin_style_updatexml.inc
@@ -95,6 +95,8 @@ class fserver_plugin_style_updatexml extends views_plugin_style {
         }
       }
     }
+    // @TODO: need to correct the api version in project tag, if we have multiple api versions
+    // we need the key "all" instead of 5.x / 6.x / 7.x /...
 
     // If this is a legacy project and has a redirect URL use it immediately.
     if (!empty($project['redirect'])) {
@@ -112,6 +114,10 @@ class fserver_plugin_style_updatexml extends views_plugin_style {
     $releases = array();
     $project['recommended_major'] = '';
     $project['supported_majors'] = array();
+    
+    // Helper array for detecting multiple API Versions... (not the best way?)
+    $multiple_api_versions = array();
+
     foreach ($vars['rows'] as $num => $row) {
       foreach ($vars['options']['release'] as $element => $field) {
         $alias = $fields[$field]->field_alias;
@@ -131,7 +137,15 @@ class fserver_plugin_style_updatexml extends views_plugin_style {
           }
         }
       }
-
+      
+      // manual mapping from project api field to release api field
+      $project_api_version_mapping = $fields[$vars['options']['project']['api_version']]->field_alias;
+      if(isset($row->{$project_api_version_mapping})) {
+        $releases[$num]['api_version'] = $fields[$vars['options']['project']['api_version']]->theme($row);
+        // add current version to helper array...
+        $multiple_api_versions[$releases[$num]['api_version']] = $releases[$num]['api_version'];
+      }
+      
       if ($releases[$num]['recommended']) {
         // Use the first major version for the project major.
         // The list is sorted by "major desc", this way the latest branch will be
@@ -144,7 +158,7 @@ class fserver_plugin_style_updatexml extends views_plugin_style {
       }
 
       // Version
-      $releases[$num]['version'] = "{$project['api_version']}-{$releases[$num]['version_major']}.{$releases[$num]['version_patch']}";
+      $releases[$num]['version'] = "{$releases[$num]['api_version']}-{$releases[$num]['version_major']}.{$releases[$num]['version_patch']}";
       if (!empty($releases[$num]['version_extra'])) {
         $releases[$num]['version'] .= "-{$releases[$num]['version_extra']}";
       }
@@ -158,8 +172,14 @@ class fserver_plugin_style_updatexml extends views_plugin_style {
       // Download link
       $releases[$num]['download_link'] = file_create_url($releases[$num]['download_link']);
     }
+
     sort($project['supported_majors']);
     $project['supported_majors'] = implode(",", $project['supported_majors']);
+    
+    // overwrite projects api version if we have multiple versions to "all"
+    if (count($multiple_api_versions) > 1) {
+      $project['api_version'] = 'all';
+    }
 
     // Finalize
     $vars['project'] = $project;


### PR DESCRIPTION
Hi,

i fixed the old deprecated drush callbacks with the new command hook system from drush. Also there was a bug with FserverProject_git the checkout part put the files in the current directory and not in the git workdir this is happend because git checkout uses --git-dir but not --work-tree option. Both problems was fixed here.

best regards
Dennis
